### PR TITLE
add light/dark mode + add js-cookie for saving mode state

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3050,7 +3050,8 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -3415,7 +3416,8 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -3463,6 +3465,7 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -3501,11 +3504,13 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.0.3",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             }
           }
         },
@@ -6869,8 +6874,7 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
@@ -6879,8 +6883,7 @@
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6983,8 +6986,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6994,7 +6996,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -7014,13 +7015,11 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -7037,7 +7036,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -7110,8 +7108,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -7121,7 +7118,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -7227,7 +7223,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -10004,6 +9999,11 @@
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.5.1.tgz",
       "integrity": "sha512-M7kLczedRMYX4L8Mdh4MzyAMM9O5osx+4FcOQuTvr3A9F2D9S5JXheN0ewNbrvK2UatkTRhL5ejGmGSjNMiZuw=="
+    },
+    "js-cookie": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.0.tgz",
+      "integrity": "sha1-Gywnmm7s44ChIWi5JIUmWzWx7/s="
     },
     "js-levenshtein": {
       "version": "1.1.6",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "create-react-class": "^15.6.3",
     "gh-pages": "^2.0.1",
     "graphql": "^14.1.1",
+    "js-cookie": "^2.2.0",
     "node-sass": "^4.11.0",
     "react": "^16.8.3",
     "react-apollo": "^2.5.1",

--- a/public/index.html
+++ b/public/index.html
@@ -47,38 +47,84 @@
     <script src="https://www.aichner-christian.com/mdb/js/popper.min.js"></script>
     <script src="https://www.aichner-christian.com/mdb/js/bootstrap.min.js"></script>
     <script src="https://www.aichner-christian.com/mdb/js/mdb.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/js-cookie@2/src/js.cookie.min.js"></script>
+    
     <script>
       // Animations initialization
       new WOW().init();
 
       $(document).ready(function() {
-        var hash = window.location.hash;
+        let hash = window.location.hash;
         if (hash !== "") {
           $("html,body").animate({
-            scrollTop: $(hash).offset().top - 120
+            scrollTop: $(hash).offset().top - 73.797
           });
         }
-      });
+       
 
-      $(document).on("click", ".sscroll", function(e) {
-        var target = $(this).attr("href");
-        e.preventDefault();
-        $("html,body").animate(
-          {
-            scrollTop: $(target).offset().top - 120
-          },
-          800,
-          "easeInOutQuart"
-        );
-      });
+        $(document).on("click", ".sscroll", function(e) {
+          let target = $(this).attr("href");
+          e.preventDefault();
+          $("html,body").animate(
+            {
+              scrollTop: $(target).offset().top - 73.797
+            },
+            800,
+            "easeInOutQuart"
+          );
+        });
 
-       // Tooltips Initialization
+        let loadDark = () => {
+          $('.asbest').attr('style', 'display: none !important;');
+          $('.graviola-container').attr('style', 'display: block !important;');
+          $('.hero-counter').attr('style', 'display: block !important;');
+          $('.navbar').removeClass("navbar-light");
+          $('.navbar').addClass("navbar-dark");
+          $('.navbar img').attr('style', 'filter: brightness(0) invert(1);');
+          $('.navbar .btn').removeClass('btn-outline-elegant');
+          $('.navbar .btn').addClass('btn-outline-white');
+        }
+
+        let loadLight = () => {
+          $('.asbest').attr('style', 'display: block !important;');
+          $('.graviola-container').attr('style', 'display: none !important;');
+          $('.hero-counter').attr('style', 'display: none !important;');
+          $('.navbar').removeClass("navbar-dark");
+          $('.navbar').addClass("navbar-light");
+          $('.navbar img').attr('style', 'filter: brightness(0) invert(0);');
+          $('.navbar .btn').removeClass('btn-outline-white');
+          $('.navbar .btn').addClass('btn-outline-elegant');
+        }
+
+        $(document).on("click", ".switch-mode", function(e) {
+          let state = $(this).is(':checked');
+          if(state === true){
+            //Dark mode - how we want it
+            loadDark();
+            toastr["success"]("Vorzeige Modus aktiviert.")
+            Cookies.set('s_mode', '1');
+          }else{
+            //Light mode
+            loadLight();
+            toastr["error"]("Vorzeige Modus deaktiviert.")
+            Cookies.set('s_mode', '0');
+          }
+        });
+
+        //Modes
+        $('.asbest').ready(function(){
+          let mode = Cookies.get('s_mode');
+          if(mode === '0'){
+            loadLight();
+          }else if(mode === '1'){
+            loadDark();
+          }
+        })
+      });
+    // Tooltips Initialization
     $(function () {
       $('[data-toggle="tooltip"]').tooltip()
     })
     </script>
-    <!--<script src="%SRC_URL%/mdb/js/jquery-3.3.1.min.js"></script>
-    <script src="%SRC_URL%/mdb/js/bootstrap.min.js"></script>
-    <script src="%SRC_URL%/mdb/js/mdb.min.js"></script>-->
   </body>
 </html>

--- a/src/App.scss
+++ b/src/App.scss
@@ -190,6 +190,8 @@ section{
 
 #interview-carousel .carousel-indicators{
     position: relative;
+    margin-left: auto !important;
+    margin-right: auto !important;
 }
 #interview-carousel .btn-floating span {
     display: inline-block;
@@ -426,7 +428,7 @@ section{
 }
 .graviola-container{
     //@include distribute-on-circle(4, 23em, 13em, false); //Desktop
-    @include distribute-on-circle(4, 11em,7em, false); //Mobile
+    @include distribute-on-circle(4, 22em,13em, false); //Mobile
     margin: 5em auto 0;
     border: solid 5px $unique-blue;
 
@@ -442,7 +444,7 @@ section{
         padding: 1em;
         p{
             margin-bottom: .5em;
-            font-size: .7em;
+            font-size: 1em;
         }
         p:last-child{
             margin-bottom: 0;
@@ -452,10 +454,10 @@ section{
             justify-content: center;
             align-items: center;
             position: absolute;
-            top: -20px;
-            left: calc(50% - 20px);
-            width: 40px;
-            height: 40px;
+            top: -30px;
+            left: calc(50% - 30px);
+            width: 60px;
+            height: 60px;
             border-radius: 100%;
         }
     }
@@ -514,6 +516,148 @@ section{
         }
     }
 }
+@media (max-width: 740px) {
+    /* Graviola (fix for asbest) */
+@mixin distribute-on-circle( 
+    $nb-items,
+    $circle-size,
+    $item-size,
+    $class-for-IE: false
+  ) {
+    $half-item: ($item-size / 2);
+    $half-parent: ($circle-size / 2);
+    
+    position: relative; /* 1 */
+    width:  $circle-size;
+    height: $circle-size;
+    margin-bottom: $item-size / 1.5!important;
+    margin-top: $item-size / 1.5 !important;
+    padding: 0;
+    border-radius: 50%; 
+    list-style: none; /* 2 */ 
+    box-sizing: content-box; /* 3 */ 
+    
+    > * { /* 4 */
+      display: block;
+      position: absolute;
+      top:  50%; 
+      left: 50%;
+      width:  $item-size;
+      height: $item-size;
+      margin: -$half-item;
+    }
+    
+    $angle: (360 / $nb-items);
+    $rot: 0;
+  
+    @for $i from 1 through $nb-items {
+      @if not $class-for-IE {
+        > :nth-of-type(#{$i}) {
+          transform: rotate($rot * 1deg) translate($half-parent) rotate($rot * -1deg);
+        }
+      } @else {
+        > .#{$class-for-IE}#{$i} {
+          // If CSS transforms are not supported
+          $mt: sin($rot * pi() / 180) * $half-parent - $half-item;
+          $ml: cos($rot * pi() / 180) * $half-parent - $half-item;
+          margin: $mt 0 0 $ml;
+        }
+      }
+  
+      $rot: ($rot + $angle);
+    }
+  }
+  .graviola-container{
+      //@include distribute-on-circle(4, 23em, 13em, false); //Desktop
+      @include distribute-on-circle(4, 11em,7em, false); //Mobile
+      margin: 5em auto 0;
+      border: solid 5px $unique-blue;
+  
+      .circle { 
+          display: block; 
+          width: 100%;
+          height: 100%;
+          border-radius: 50%;
+          display: flex;
+          flex-direction: column;
+          justify-content: center;
+          align-items: center;
+          padding: 1em;
+          p{
+              margin-bottom: .5em;
+              font-size: .7em;
+          }
+          p:last-child{
+              margin-bottom: 0;
+          }
+          &::before{
+              display: flex;
+              justify-content: center;
+              align-items: center;
+              position: absolute;
+              top: -20px;
+              left: calc(50% - 20px);
+              width: 40px;
+              height: 40px;
+              border-radius: 100%;
+          }
+      }
+      .circle-blue{
+          p{
+              color: white;
+          }
+          a{
+              color: white;
+          }
+          a:hover{
+              color: #f9f9f9;
+          }
+          background-color: $unique-blue;
+      }
+      .circle-white{
+          p{
+              color: $unique-blue;
+          }
+          a{
+              color: $unique-blue;
+          }
+          a:hover{
+              color: #95b2c9;
+          }
+          background-color: white;
+      }
+      .c1{
+          &::before{
+              content: "1";
+              background-color: white;
+              color: $unique-blue;
+          }
+      }
+      .c2{
+          &::before{
+              content: "2";
+              background-color: $unique-blue;
+              color: white;
+          }
+      }
+      .c3{
+          &::before{
+              content: "3";
+              top: unset !important;
+              bottom: -20px;
+              background-color: white;
+              color: $unique-blue;
+          }
+      }
+      .c4{
+          &::before{
+              content: "4";
+              background-color: $unique-blue;
+              color: white;
+          }
+      }
+  }
+}
 
 /* Footer */
 .page-footer .container{
@@ -525,6 +669,15 @@ footer.page-footer a {
 }
 footer .email-link {
     text-transform: none !important;
+}
+footer .switch label input[type=checkbox]:checked+.lever{
+    background-color: $unique-blue !important;
+}
+footer .switch label .lever{
+    background-color: lightgrey;
+}
+footer .lever::after{
+    background-color: #F1F1F1 !important;
 }
 
 /* Fix cards */

--- a/src/components/molecules/Hero/index.js
+++ b/src/components/molecules/Hero/index.js
@@ -62,7 +62,7 @@ const Hero = (props: Props): React.Element<*> => {
                             <div className="row white-text">
                               
                                 <div className="col-md-12 text-right">
-                                    <p className="d-none">{i+1} - {heroitems.length}</p>
+                                    <p className="hero-counter d-none">{i+1} - {heroitems.length}</p>
                                 </div>
                             </div>
                         </div>

--- a/src/components/organisms/Footer/index.js
+++ b/src/components/organisms/Footer/index.js
@@ -1,9 +1,21 @@
 import * as React from 'react'
+import Cookies from 'js-cookie'
 
 type Props = {
     sociallinks: string,
     companyinfo: string,
     logo: string
+}
+
+let getMode = () => {
+  let val = Cookies.get('s_mode');
+  if(val === '0'){
+    return false;
+  }else if(val === '1'){
+    return true;
+  }else{
+    return false;
+  }
 }
 
 const Footer = (props: Props): React.Element<*> => {
@@ -65,10 +77,14 @@ const Footer = (props: Props): React.Element<*> => {
       <hr/>
 
       <div className="row d-flex align-items-center dark-grey-text">
-        <div className="col-md-7 col-lg-8">
+        <div className="col-md-6">
           <p className="text-center text-md-left">© 2018 - {(new Date().getFullYear())} Copyright: {companyinfo[0].copyrightholder}
           </p>
-
+        </div>
+        <div className="col-md-6 text-right">
+          <div className="switch">
+            <label>Light<input className="switch-mode" type="checkbox" defaultChecked={getMode()}/><span className="lever"></span>Dark</label>
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/organisms/Modal/index.js
+++ b/src/components/organisms/Modal/index.js
@@ -39,9 +39,9 @@ const Modal = (props: Props): React.Element<*> => {
                         <div className="splitter my-4"><span className="or"><span className="or-text">oder</span></span></div>
                     </div>
                     <form id="form-reg" onSubmit={(e) => {handleSubmit(e); e.preventDefault();}}>
-                        <div className="input-grp"><i class="fas fa-phone" data-toggle="tooltip" title="Um Sie zu kontaktieren, benötigen wir Ihre Telefonnummer"></i><input className="form-control my-3" type="text" name="phone" placeholder="Telefonnummer"/></div>
-                        <div className="input-grp"><i class="far fa-user-circle" data-toggle="tooltip" title="Eine persönliche Kommunikation ist uns sehr wichtig."></i><input className="form-control my-3" type="text" name="prename" placeholder="Vorname"/></div>
-                        <div className="input-grp"><i class="far fa-user-circle" data-toggle="tooltip" title="Eine persönliche Kommunikation ist uns sehr wichtig."></i><input className="form-control my-3" type="text" name="surname" placeholder="Nachname"/></div>
+                        <div className="input-grp"><i className="fas fa-phone" data-toggle="tooltip" title="Um Sie zu kontaktieren, benötigen wir Ihre Telefonnummer"></i><input className="form-control my-3" type="text" name="phone" placeholder="Telefonnummer"/></div>
+                        <div className="input-grp"><i className="far fa-user-circle" data-toggle="tooltip" title="Eine persönliche Kommunikation ist uns sehr wichtig."></i><input className="form-control my-3" type="text" name="prename" placeholder="Vorname"/></div>
+                        <div className="input-grp"><i className="far fa-user-circle" data-toggle="tooltip" title="Eine persönliche Kommunikation ist uns sehr wichtig."></i><input className="form-control my-3" type="text" name="surname" placeholder="Nachname"/></div>
                         <div className="text-center mt-4" dangerouslySetInnerHTML={{__html: data.step1}}></div>
                         <input className="btn btn-outline-elegant" type="submit" value="Starten" />
                     </form>

--- a/src/components/organisms/SectionContents/0.js
+++ b/src/components/organisms/SectionContents/0.js
@@ -33,7 +33,7 @@ const SectionContent = (props: Props): React.Element<*> => {
                     </div>
                 </div>
             </div>
-            <ModalBtn btnstyle="WHITE" modal="#modalRegister" className="font-weight-bold">Launch modal</ModalBtn>
+            <ModalBtn btnstyle="WHITE" modal="#modalRegister" className="font-weight-bold">Beautyprogramm starten</ModalBtn>
         </div>
     )
 }

--- a/src/components/organisms/SectionContents/6.js
+++ b/src/components/organisms/SectionContents/6.js
@@ -20,8 +20,7 @@ const SectionContent = (props: Props): React.Element<*> => {
            <h2 className="h1-responsive font-weight-bold mb-5">{content[0].heading}</h2>
 
             <div className="wrapper-carousel-fix">
-                <div id="customer-carousel" className="carousel no-flex testimonial-carousel slide py-5 dark-grey-text" data-ride="carousel"
-                data-interval="10000">
+                <div id="customer-carousel" className="carousel no-flex testimonial-carousel slide py-5 dark-grey-text" data-ride="carousel" data-interval="20000">
                 <div className="carousel-inner" role="listbox">
                 {reviews.map((item, i) => {
                     return(


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change?
 - [x] Have you tested your changes with successful results?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
- Asbest works for desktop, Graviola for mobile
- The carousel in section 6 does not auto-slide
- The navigation buttons in section 5 are ellipses in mobile view (margin-right / margin-left)

**What is the new behavior (if this is a feature change)?**
- Graviola replaces Asbest on desktop and mobile, by applying Dark mode
- The hero slide-counter is now visible in dark mode
- The navigation bar now appears dark in dark mode
- The carousel in section 6 now auto-slides
- The navigation buttons in section 5 now appear as circles as intended